### PR TITLE
Changed UI of board and column selection

### DIFF
--- a/components/BoardSelector.jsx
+++ b/components/BoardSelector.jsx
@@ -9,7 +9,7 @@ export default ({groupedboards, onChange}) => {
         return <optgroup key={key} label={key}>
           {(
               group.map(function (board) {
-                return <option key={board.id} className={"btn btn-large"} value={board.id}>{board.name}</option>
+                return <option key={board.id} value={board.id}>{board.name}</option>
               }.bind(this))
           )} </optgroup>
       }.bind(this))

--- a/components/ListSelector.jsx
+++ b/components/ListSelector.jsx
@@ -6,7 +6,7 @@ export default ({lists, onChange}) => {
         {
 
             lists.map(function (list) {
-                return <option key={list.id} className={"btn btn-large"} value={list.id}>{list.name}</option>
+                return <option key={list.id}  value={list.id}>{list.name}</option>
             }.bind(this))
         }
     </select>


### PR DESCRIPTION
There was a problem when a user has a lot of boards:

<img width="1280" alt="screen shot 2017-02-19 at 09 49 21" src="https://cloud.githubusercontent.com/assets/5879/23100763/34a9c328-f689-11e6-8144-ce2ae3e3bb9f.png">

Now i removed the `btn` classes so it's a normal select.